### PR TITLE
Resolve "`last_price_time` and `last_status_update` must not be tracked in the database"

### DIFF
--- a/src/infinity_grid/infrastructure/database.py
+++ b/src/infinity_grid/infrastructure/database.py
@@ -8,12 +8,11 @@
 """Module implementing the database connection and handling of interactions."""
 
 from copy import deepcopy
-from datetime import datetime
 from importlib.metadata import version
 from logging import getLogger
 from typing import Any, Self
 
-from sqlalchemy import Column, DateTime, Float, Integer, String, Table, func, select
+from sqlalchemy import Column, Float, Integer, String, Table, func, select
 from sqlalchemy.engine.result import MappingResult
 from sqlalchemy.engine.row import RowMapping
 
@@ -163,8 +162,6 @@ class Configuration:
             Column("price_of_highest_buy", Float, nullable=False, default=0),
             Column("amount_per_grid", Float),
             Column("interval", Float),
-            Column("last_price_time", DateTime, nullable=False),
-            Column("last_status_update", DateTime, nullable=False),
             extend_existing=True,
         )
 
@@ -182,8 +179,6 @@ class Configuration:
                 self.__table,
                 userref=self.__userref,
                 version=current_version,
-                last_price_time=datetime.now(),
-                last_status_update=datetime.now(),
             )
         # Check if version needs to be updated
         elif (config := self.get()) and config.version != current_version:  # type: ignore[attr-defined]
@@ -210,8 +205,6 @@ class Configuration:
                 - price_of_highest_buy: Price of the highest buy order
                 - amount_per_grid: Amount allocated per grid
                 - interval: Interval setting
-                - last_price_time: Timestamp of last price update
-                - last_status_update: Timestamp of last status update
         """
         if not filters:
             filters = {}

--- a/src/infinity_grid/strategies/grid_base.py
+++ b/src/infinity_grid/strategies/grid_base.py
@@ -89,10 +89,10 @@ class GridStrategyBase:
 
         # Tracks the last time a ticker message was received for checking
         # connectivity.
-        self._last_price_time: datetime = None
-        # Memory the last time when a status notification was sent to ensure
+        self._last_price_time: datetime | None = None
+        # Remember the last time when a status notification was sent to ensure
         # this only happens once an hour.
-        self._last_status_update: datetime = None
+        self._last_status_update: datetime | None = None
 
         self._cost_decimals: int
         self._amount_per_grid_plus_fee: float


### PR DESCRIPTION
Since tracking of the last ticker time, as well as the time when the last status update was sent are not important for saving between instance runs, they can be safely deleted from the database schema. Since sqlalchemy takes care to ignore unused columns, this change is backward compatible.

Closes #16 