### PR TITLE
Fix the ghcr.io container upload

### DIFF
--- a/.github/workflows/_ghcr_publish.yaml
+++ b/.github/workflows/_ghcr_publish.yaml
@@ -64,13 +64,17 @@ jobs:
       - name: Tag and push to GHCR
         id: push
         run: |
+          DIGEST=""
           for tag in ${{ steps.meta.outputs.tags }}; do
             docker tag btschwertfeger/infinity-grid:build-artifact $tag
             docker push $tag
+
+            # Get digest from the first pushed tag
+            if [ -z "$DIGEST" ]; then
+              DIGEST=$(docker image inspect $tag --format='{{index .RepoDigests 0}}' | cut -d'@' -f2)
+            fi
           done
 
-          # Get digest for attestation
-          DIGEST=$(docker inspect ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }} --format='{{index .RepoDigests 0}}' | cut -d'@' -f2)
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 
       - name: Generate artifact attestation


### PR DESCRIPTION
# Summary

Publishing to ghcr.io failed, due to a wrongly configured publish workflow. 
This was fixed by using the correct tag to retrieve the digest for attestation.

https://github.com/btschwertfeger/infinity-grid/actions/runs/17722957337/job/50358657929
