### PR TITLE
Allow dependabot deploy, update container image labels and distributed tags

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,19 +5,19 @@ updates:
     schedule:
       interval: monthly
     groups:
-      all:
+      github-actions:
         dependency-type: production
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: monthly
     groups:
-      all:
+      docker:
         dependency-type: production
   - package-ecosystem: docker-compose
     directory: /
     schedule:
       interval: monthly
     groups:
-      all:
+      docker-compose:
         dependency-type: production

--- a/.github/workflows/_build_image.yaml
+++ b/.github/workflows/_build_image.yaml
@@ -47,6 +47,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Get current date
+        id: date
+        run: echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
+      - name: Get version
+        id: version
+        run: |
+          if [[ "${{ github.ref_type }}" == "tag" ]]; then
+            echo "version=${{ github.ref_name }}" >> $GITHUB_OUTPUT
+          else
+            # Extract version from the built wheel filename
+            wheel_file=$(ls dist/*.whl | head -1)
+            version=$(basename "$wheel_file" | sed 's/infinity_grid-\([^-]*\)-.*/\1/')
+            echo "version=${version}" >> $GITHUB_OUTPUT
+          fi
+
       - name: Build Docker image
         uses: docker/build-push-action@v6.18.0
         with:
@@ -55,6 +71,9 @@ jobs:
           push: false
           load: true
           tags: btschwertfeger/infinity-grid:build-artifact
+          build-args: |
+            VERSION=${{ steps.version.outputs.version }}
+            CREATE_TIME=${{ steps.date.outputs.date }}
 
       - name: Test Docker image
         run: docker run --rm --entrypoint=infinity-grid btschwertfeger/infinity-grid:build-artifact --help

--- a/.github/workflows/_dockerhub_publish.yaml
+++ b/.github/workflows/_dockerhub_publish.yaml
@@ -61,6 +61,14 @@ jobs:
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
         with:
           images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Tag and push to Docker Hub
         run: |

--- a/.github/workflows/_ghcr_publish.yaml
+++ b/.github/workflows/_ghcr_publish.yaml
@@ -61,6 +61,14 @@ jobs:
         uses: docker/metadata-action@c1e51972afc2121e065aed6d45c65596fe445f3f
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
 
       - name: Tag and push to GHCR
         id: push

--- a/.github/workflows/_shared_cicd.yaml
+++ b/.github/workflows/_shared_cicd.yaml
@@ -131,7 +131,7 @@ jobs:
     if: |
       success()
       && inputs.run_pull_request
-      && github.actor == 'btschwertfeger'
+      && (github.actor == 'btschwertfeger' || github.actor == 'dependabot[bot]')
     needs: [Pre-Commit]
     uses: ./.github/workflows/_helm_test.yaml
     secrets:
@@ -144,7 +144,7 @@ jobs:
     if: |
       success()
       && inputs.run_pull_request
-      && github.actor == 'btschwertfeger'
+      && (github.actor == 'btschwertfeger' || github.actor == 'dependabot[bot]')
     needs: [Validate-Chart, Build-Docker]
     uses: ./.github/workflows/_ghcr_pr_publish.yaml
     with:
@@ -157,7 +157,7 @@ jobs:
     if: |
       success()
       && inputs.run_pull_request
-      && github.actor == 'btschwertfeger'
+      && (github.actor == 'btschwertfeger' || github.actor == 'dependabot[bot]')
     needs: [UploadGHCR-PR]
     uses: ./.github/workflows/_helm_pr_deploy.yaml
     with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@
 FROM python:3.13-slim-bookworm
 
 ARG EXTRAS="kraken"
+ARG VERSION
+ARG CREATE_TIME
 
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -46,9 +48,11 @@ USER infinity-grid
 
 ENTRYPOINT ["infinity-grid", "run"]
 
-LABEL title="Infinity Grid"
-LABEL maintainer="Benjamin Thomas Schwertfeger contact@b-schwertfeger.de"
-LABEL description="The Infinity Grid Trading Algorithm."
-LABEL documentation="https://infinity-grid.readthedocs.io/en/stable"
-LABEL image.url="https://github.com/btschwerfeger/infinity-grid"
+LABEL org.opencontainers.description="The Infinity Grid Trading Algorithm."
+LABEL org.opencontainers.documentation="https://infinity-grid.readthedocs.io/en/stable"
+LABEL org.opencontainers.image.authors="Benjamin Thomas Schwertfeger contact@b-schwertfeger.de"
 LABEL org.opencontainers.image.source="https://github.com/btschwerfeger/infinity-grid"
+LABEL org.opencontainers.license="LicenseRef-Infinity-Grid-2.0"
+LABEL org.opencontainers.title="Infinity Grid"
+LABEL org.opencontainers.version=${VERSION}
+LABEL org.opencontainers.created=${CREATE_TIME}

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,10 @@ doc:
 ## image	Build the Docker image
 ##
 image:
-	docker build -t btschwertfeger/infinity-grid:dev .
+	docker build \
+	--build-arg VERSION=dev \
+	--build-arg CREATE_TIME=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ") \
+	-t btschwertfeger/infinity-grid:dev .
 
 ## ======= I N S T A L L A T I O N =============================================
 ## install	Install the package

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,19 +1,25 @@
 # -*- mode: yaml; coding: utf-8 -*-
 #
-# Copyright (C) 2023 Benjamin Thomas Schwertfeger All rights reserved.
+# Copyright (C) 2023 Benjamin Thomas Schwertfeger
+# All rights reserved.
 # https://github.com/btschwertfeger
 #
 # ------------------------------------------------------------------------------
-# This Docker Compose file creates a PostgreSQL and infinity-grid container.
+# This Docker Compose file creates an infinity-grid and PostgreSQL container.
 #
-# In order to use this file to run the trading algorithm, a few environment
-# variables must be set, see https://infinity-grid.readthedocs.io/en/latest/ for
-# more information.
+# To run the trading algorithm with this file, configure the environment
+# variables accordingly. See https://infinity-grid.readthedocs.io/en/stable/ for
+# complete documentation.
 #
 # Note: For running multiple instances of the infinity-grid in parallel, you can
 #       simply duplicate and configure the service, as it supports sharing the
 #       same database. BUT: Keep in mind to use different API keys as well as
 #       different userref's! Otherwise you will encounter errors.
+# Note: Before increasing the version number of the infinity-grid, please check
+#       the release notes for breaking changes.
+# Note: Do not update the PostgreSQL version that serves a running infinity-grid
+#       instance unless absolutely necessary. Here again, read the release
+#       notes. and always create a backup before making changes.
 # ------------------------------------------------------------------------------
 
 name: infinity-grid


### PR DESCRIPTION
## Allow dependabot[bot] to create review deployments

The dependabot[bot] can now create review deployments from within pull requests

## Update image tagging

When publishing the image, multiple image tags will be pushed for a single release tag. 

Example: New release v1.2.0 will push the tags 1.2.0, 1.2, and 1.

## Updating the container image labels

Updated the container image labels according to https://github.com/opencontainers/image-spec/blob/main/annotations.md. 

```json
{
  "org.opencontainers.created": "2025-09-16T04:52:23Z",
  "org.opencontainers.description": "The Infinity Grid Trading Algorithm.",
  "org.opencontainers.documentation": "https://infinity-grid.readthedocs.io/en/stable",
  "org.opencontainers.image.authors": "Benjamin Thomas Schwertfeger contact@b-schwertfeger.de",
  "org.opencontainers.image.source": "https://github.com/btschwerfeger/infinity-grid",
  "org.opencontainers.license": "LicenseRef-Infinity-Grid-2.0",
  "org.opencontainers.title": "Infinity Grid",
  "org.opencontainers.version": "dev"
}
```


