### PR TITLE
Extend the test suite

### DIFF
--- a/.github/workflows/_codecov.yaml
+++ b/.github/workflows/_codecov.yaml
@@ -88,7 +88,7 @@ jobs:
         env:
           INFINITY_GRID_API_PUBLIC_KEY: ${{ secrets.INFINITY_GRID_API_PUBLIC_KEY }}
           INFINITY_GRID_API_SECRET_KEY: ${{ secrets.INFINITY_GRID_API_SECRET_KEY }}
-        run: pytest -vv --cov=infinity_grid --cov-report=xml:coverage.xml tests
+        run: pytest -vv -x --cov=infinity_grid --cov-report=xml:coverage.xml tests
 
       - name: Export coverage report
         uses: actions/upload-artifact@v4

--- a/.github/workflows/_codecov.yaml
+++ b/.github/workflows/_codecov.yaml
@@ -22,6 +22,10 @@ on:
     secrets:
       CODECOV_TOKEN:
         required: true
+      INFINITY_GRID_API_PUBLIC_KEY:
+        required: true
+      INFINITY_GRID_API_SECRET_KEY:
+        required: true
 
 permissions:
   contents: read
@@ -81,6 +85,9 @@ jobs:
           uv pip install "$(find dist -name '*.whl' | head -1)" -r requirements-dev.txt
 
       - name: Generate coverage report
+        env:
+          INFINITY_GRID_API_PUBLIC_KEY: ${{ secrets.INFINITY_GRID_API_PUBLIC_KEY }}
+          INFINITY_GRID_API_SECRET_KEY: ${{ secrets.INFINITY_GRID_API_SECRET_KEY }}
         run: pytest -vv --cov=infinity_grid --cov-report=xml:coverage.xml tests
 
       - name: Export coverage report

--- a/.github/workflows/_shared_cicd.yaml
+++ b/.github/workflows/_shared_cicd.yaml
@@ -107,6 +107,9 @@ jobs:
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
+    secrets:
+      INFINITY_GRID_API_PUBLIC_KEY: ${{ secrets.INFINITY_GRID_API_PUBLIC_KEY }}
+      INFINITY_GRID_API_SECRET_KEY: ${{ secrets.INFINITY_GRID_API_SECRET_KEY }}
 
   ## ===========================================================================
   ##    Generates and uploads the coverage statistics to codecov
@@ -123,6 +126,8 @@ jobs:
       python-version: "3.11"
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      INFINITY_GRID_API_PUBLIC_KEY: ${{ secrets.INFINITY_GRID_API_PUBLIC_KEY }}
+      INFINITY_GRID_API_SECRET_KEY: ${{ secrets.INFINITY_GRID_API_SECRET_KEY }}
 
   ## ===========================================================================
   ##    Validate the Helm Chart (only in PR runs)

--- a/.github/workflows/_shared_cicd.yaml
+++ b/.github/workflows/_shared_cicd.yaml
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.11", "3.12", "3.13"] # just for compatibility reasons
     with:
       os: ${{ matrix.os }}
@@ -102,14 +102,11 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.11", "3.12", "3.13"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
-    secrets:
-      INFINITY_GRID_API_PUBLIC_KEY: ${{ secrets.INFINITY_GRID_API_PUBLIC_KEY }}
-      INFINITY_GRID_API_SECRET_KEY: ${{ secrets.INFINITY_GRID_API_SECRET_KEY }}
 
   ## ===========================================================================
   ##    Generates and uploads the coverage statistics to codecov

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -18,11 +18,6 @@ on:
       python-version:
         type: string
         required: true
-    secrets:
-      INFINITY_GRID_API_PUBLIC_KEY:
-        required: true
-      INFINITY_GRID_API_SECRET_KEY:
-        required: true
 
 permissions:
   contents: read
@@ -73,7 +68,4 @@ jobs:
           uv pip install "$wheel" -r requirements-dev.txt
 
       - name: Run the tests
-        env:
-          INFINITY_GRID_API_PUBLIC_KEY: ${{ secrets.INFINITY_GRID_API_PUBLIC_KEY }}
-          INFINITY_GRID_API_SECRET_KEY: ${{ secrets.INFINITY_GRID_API_SECRET_KEY }}
-        run: pytest -vv tests
+        run: pytest -vv -x tests

--- a/.github/workflows/_test.yaml
+++ b/.github/workflows/_test.yaml
@@ -18,6 +18,11 @@ on:
       python-version:
         type: string
         required: true
+    secrets:
+      INFINITY_GRID_API_PUBLIC_KEY:
+        required: true
+      INFINITY_GRID_API_SECRET_KEY:
+        required: true
 
 permissions:
   contents: read
@@ -68,4 +73,7 @@ jobs:
           uv pip install "$wheel" -r requirements-dev.txt
 
       - name: Run the tests
+        env:
+          INFINITY_GRID_API_PUBLIC_KEY: ${{ secrets.INFINITY_GRID_API_PUBLIC_KEY }}
+          INFINITY_GRID_API_SECRET_KEY: ${{ secrets.INFINITY_GRID_API_SECRET_KEY }}
         run: pytest -vv tests

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 UV ?= uv
 PYTHON := python
 PYTEST := pytest
-PYTEST_OPTS := -vv --junit-xml=pytest.xml -n auto
+PYTEST_OPTS := -vv --junit-xml=pytest.xml
 PYTEST_COV_OPTS := $(PYTEST_OPTS) --cov=infinity_grid --cov-report=xml:coverage.xml --cov-report=term-missing --cov-report=html
 TEST_DIR := tests
 

--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,8 @@
 UV ?= uv
 PYTHON := python
 PYTEST := pytest
-PYTEST_OPTS := -vv --junit-xml=pytest.xml
-PYTEST_COV_OPTS := $(PYTEST_OPTS) --cov=infinity_grid --cov-report=xml:coverage.xml --cov-report=term-missing
+PYTEST_OPTS := -vv --junit-xml=pytest.xml -n auto
+PYTEST_COV_OPTS := $(PYTEST_OPTS) --cov=infinity_grid --cov-report=xml:coverage.xml --cov-report=term-missing --cov-report=html
 TEST_DIR := tests
 
 ## ======= H E L P =============================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ markers = [
   "asyncio: used for async tests.",
   "integration: used for integration tests.",
   "wip: used for wip tests.",
+  "acceptance: marks tests as acceptance tests",
 ]
 asyncio_default_fixture_loop_scope = "function"
 filterwarnings = [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 pytest
 pytest-asyncio
 pytest-cov
+pytest-timeout
 python-kraken-sdk~=3.2

--- a/src/infinity_grid/adapters/exchanges/kraken.py
+++ b/src/infinity_grid/adapters/exchanges/kraken.py
@@ -318,11 +318,6 @@ class KrakenExchangeRESTServiceAdapter(IExchangeRESTService):
         return f"{self.__base_currency}/{self.__quote_currency}"
 
     @cached_property
-    def ws_altname(self: Self) -> str:
-        base_currency, quote_currency = self.rest_symbol.split("/")
-        return f"{base_currency}{quote_currency}"
-
-    @cached_property
     def rest_symbol(self: Self) -> str:
         """Returns the symbol for the given base and quote currency."""
         asset_response = self.__market_service.get_assets(

--- a/src/infinity_grid/core/cli.py
+++ b/src/infinity_grid/core/cli.py
@@ -21,6 +21,8 @@ from infinity_grid.models.configuration import (
     TelegramConfigDTO,
 )
 
+LOG = getLogger(__name__)
+
 
 def print_version(ctx: Context, param: Any, value: Any) -> None:  # noqa: ANN401, ARG001
     """Prints the version of the package"""
@@ -122,6 +124,9 @@ def cli(ctx: Context, **kwargs: dict) -> None:
     else:
         getLogger("websockets").setLevel(WARNING)
         getLogger("kraken").setLevel(WARNING)
+
+    if sys.platform == "win32":
+        LOG.warning("The infinity-grid does not fully support Windows.")
 
 
 @cli.command(
@@ -415,9 +420,6 @@ def run(ctx: Context, **kwargs: dict[str, Any]) -> None:
         port=kwargs.pop("metrics_port"),
     )
     ctx.obj |= kwargs
-
-    if sys.platform == "win32":
-        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
     asyncio.run(
         BotEngine(

--- a/src/infinity_grid/core/cli.py
+++ b/src/infinity_grid/core/cli.py
@@ -5,6 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
+import sys
 from logging import DEBUG, INFO, WARNING, basicConfig, getLogger
 from typing import Any
 
@@ -414,6 +415,9 @@ def run(ctx: Context, **kwargs: dict[str, Any]) -> None:
         port=kwargs.pop("metrics_port"),
     )
     ctx.obj |= kwargs
+
+    if sys.platform == "win32":
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
     asyncio.run(
         BotEngine(

--- a/src/infinity_grid/interfaces/exchange.py
+++ b/src/infinity_grid/interfaces/exchange.py
@@ -228,20 +228,6 @@ class IExchangeRESTService(ABC):
             "This method must be implemented in the concrete exchange class.",
         )
 
-    @property
-    @abstractmethod
-    def ws_altname(self) -> str:
-        """Returns the alternative name for the given base and quote currency.
-
-        The return value is currently not used.
-
-        This method must be implemented with the @cached_property or @property
-        decorator.
-        """
-        raise NotImplementedError(
-            "This method must be implemented in the concrete exchange class.",
-        )
-
     # == Getters for exchange trade operations =================================
     @abstractmethod
     def create_order(

--- a/tests/acceptance/__init__.py
+++ b/tests/acceptance/__init__.py
@@ -1,0 +1,8 @@
+# -*- mode: python; coding: utf-8 -*-
+#
+# Copyright (C) 2025 Benjamin Thomas Schwertfeger
+# All rights reserved.
+# https://github.com/btschwertfeger
+#
+
+"""Acceptance tests for the Infinity Grid trading bot."""

--- a/tests/acceptance/test_cli_startup.py
+++ b/tests/acceptance/test_cli_startup.py
@@ -1,0 +1,119 @@
+# -*- mode: python; coding: utf-8 -*-
+#
+# Copyright (C) 2025 Benjamin Thomas Schwertfeger
+# All rights reserved.
+# https://github.com/btschwertfeger
+#
+
+"""
+Acceptance tests for the Infinity Grid CLI.
+
+These tests verify that the bot can be started from the command line
+and transitions through the expected states correctly.
+
+This test suite requires valid API keys set in the environment:
+- INFINITY_GRID_API_PUBLIC_KEY
+- INFINITY_GRID_API_SECRET_KEY
+
+These MUST be configured to not allow creation or closing of real orders. Also
+make sure that the API keys have the necessary permissions to *only* read data.
+"""
+
+import os
+from typing import Self
+from unittest import mock
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from infinity_grid.core.cli import cli
+from infinity_grid.core.state_machine import States
+
+API_PUBLIC_KEY = os.getenv("INFINITY_GRID_API_PUBLIC_KEY")
+API_SECRET_KEY = os.getenv("INFINITY_GRID_API_SECRET_KEY")
+
+
+@pytest.mark.acceptance
+class TestCLIStartup:
+    """Test suite for CLI startup and basic lifecycle"""
+
+    @pytest.mark.timeout(30)
+    @pytest.mark.skipif(
+        API_PUBLIC_KEY is None or API_SECRET_KEY is None,
+        reason="Environment variables 'INFINITY_GRID_API_PUBLIC_KEY' and"
+        " 'INFINITY_GRID_API_SECRET_KEY' must be set!",
+    )
+    @pytest.mark.parametrize("exchange", ["Kraken"])
+    @mock.patch("infinity_grid.adapters.exchanges.kraken.sleep", return_value=None)
+    @mock.patch("infinity_grid.strategies.grid_base.sleep", return_value=None)
+    def test_cli_starts_and_reaches_running_state(
+        self: Self,
+        mock_sleep1: mock.MagicMock,  # noqa: ARG002
+        mock_sleep2: mock.MagicMock,  # noqa: ARG002
+        cli_runner: CliRunner,
+        exchange: str,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """
+        Test that the infinity-grid bot can be started via CLI with --in-memory
+        and --debug flags, and successfully reaches the RUNNING state before
+        being gracefully shutdown.
+
+        This test:
+        1. Starts the bot with minimal configuration using Click's CliRunner
+        2. Intercepts the state machine to detect RUNNING state
+        3. Triggers shutdown when RUNNING state is reached
+        4. Verifies the bot shuts down cleanly
+        """
+        caplog.set_level("INFO")
+
+        from infinity_grid.core.state_machine import StateMachine
+
+        running_state_reached = [False]  # Use list for mutability in nested scope
+        original_transition_to = StateMachine.transition_to
+
+        def mock_transition_to(self: Self, new_state: States) -> None:
+            """Mock transition_to to detect RUNNING state and trigger shutdown"""
+            original_transition_to(self, new_state)
+
+            # When RUNNING state is reached, immediately request shutdown
+            if new_state == States.RUNNING and not running_state_reached[0]:
+                running_state_reached[0] = True
+                original_transition_to(self, States.SHUTDOWN_REQUESTED)
+
+        with patch.object(StateMachine, "transition_to", mock_transition_to):
+            result = cli_runner.invoke(
+                cli,
+                [
+                    "-vv",
+                    "run",
+                    "--strategy",
+                    "GridHODL",
+                    "--name",
+                    "acceptance-test-bot",
+                    "--exchange",
+                    exchange,
+                    "--userref",
+                    "999999",
+                    "--base-currency",
+                    "BTC",
+                    "--quote-currency",
+                    "USD",
+                    "--amount-per-grid",
+                    "100",
+                    "--interval",
+                    "0.02",
+                    "--n-open-buy-orders",
+                    "3",
+                    "--in-memory",
+                    "--dry-run",  # Don't execute real trades
+                    "--skip-permission-check",  # Skip API key validation
+                ],
+                catch_exceptions=False,
+            )
+
+        assert running_state_reached[0], "Bot never reached RUNNING state"
+        assert (
+            "RUNNING" in result.output or running_state_reached[0]
+        ), "Bot did not log RUNNING state transition"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@
 #
 
 import pytest
+from click.testing import CliRunner
 
 from infinity_grid.models.configuration import DBConfigDTO
 
@@ -20,3 +21,8 @@ def db_config() -> DBConfigDTO:
         database="test_db",
         sqlite_file=":memory:",
     )
+
+
+@pytest.fixture
+def cli_runner() -> CliRunner:
+    return CliRunner()

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -10,36 +10,29 @@
 import os
 from unittest.mock import AsyncMock, MagicMock, patch
 
-import pytest
 from click.testing import CliRunner
 
 from infinity_grid.core.cli import cli
 
-
-@pytest.fixture
-def runner() -> CliRunner:
-    return CliRunner()
-
-
 # ==============================================================================
 
 
-def test_cli_help(runner: CliRunner) -> None:
+def test_cli_help(cli_runner: CliRunner) -> None:
     """Test the help message"""
-    result = runner.invoke(cli, ["--help"])
+    result = cli_runner.invoke(cli, ["--help"])
     assert result.exit_code == 0
     assert "Usage:" in result.output
 
 
-def test_cli_version(runner: CliRunner) -> None:
+def test_cli_version(cli_runner: CliRunner) -> None:
     """Test the version message"""
-    result = runner.invoke(cli, ["--version"])
+    result = cli_runner.invoke(cli, ["--version"])
     assert result.exit_code == 0
 
 
 @patch.dict(os.environ, {})
 @patch("infinity_grid.core.engine.BotEngine", new_callable=MagicMock)
-def test_cli_run(mock_bot: MagicMock, runner: CliRunner) -> None:
+def test_cli_run(mock_bot: MagicMock, cli_runner: CliRunner) -> None:
     """Test the run command"""
     command = [
         "--api-public-key",
@@ -68,7 +61,7 @@ def test_cli_run(mock_bot: MagicMock, runner: CliRunner) -> None:
         "Kraken",
     ]
     mock_bot.return_value.run = AsyncMock()
-    result = runner.invoke(cli, command)
+    result = cli_runner.invoke(cli, command)
 
     assert result.exit_code == 0, result.stderr
     mock_bot.assert_called_once()


### PR DESCRIPTION
Extending the test suite by adding an acceptance test that starts the infinity-grid in debug mode to verify that it can basically start. This tests excludes the verification of API key permissions for several reasons:

- Simplicity
- Security (financial as well as exposing keys publicly)

I also found out that the signalling stuff doesn't work on Windows. And since I don't have access to a Windows PC to properly debug or test alternative signal handling, I just disabled the Windows building and testing + log a warning in case someone tries to run the infinity-grid on Windows. 