### PR TITLE
Resolve "Manually adding an order with used userref not recognized by the infinity-grid instance"

### DIFF
--- a/src/infinity_grid/strategies/grid_base.py
+++ b/src/infinity_grid/strategies/grid_base.py
@@ -1176,11 +1176,12 @@ class GridStrategyBase:
         if self._pending_txids_table.count(filters={"txid": order_details.txid}) != 0:
             self._orderbook_table.add(order_details)
             self._pending_txids_table.remove(order_details.txid)
-        else:
-            self._orderbook_table.update(
-                order_details,
-            )
+        elif self._orderbook_table.count(filters={"txid": order_details.txid}) != 0:
+            self._orderbook_table.update(order_details)
             LOG.info("Updated order '%s' in orderbook.", order_details.txid)
+        else:
+            self._orderbook_table.add(order_details)
+            LOG.info("Added order '%s' to orderbook.", order_details.txid)
 
         LOG.info(
             "Current investment: %f / %d %s",


### PR DESCRIPTION
The algorithm tries to update an order when received, but this only works for the case that the order is already present in the database. This is not the case for the special case of placing an order manually using the same userref than one of the running instances is using. 

This issues was resolved by first checking if an order is known, before updating or adding it to the orderbook.

Closes #48 