### PR TITLE
Fix: Image upload failed on tag release

### DIFF
--- a/.github/workflows/_dockerhub_publish.yaml
+++ b/.github/workflows/_dockerhub_publish.yaml
@@ -64,11 +64,10 @@ jobs:
           tags: |
             type=schedule
             type=ref,event=branch
-            type=ref,event=tag
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=ref,event=tag
+            type=semver,pattern=v{{major}}.{{minor}}-latest
+            type=semver,pattern=v{{major}}-latest
 
       - name: Tag and push to Docker Hub
         env:

--- a/.github/workflows/_dockerhub_publish.yaml
+++ b/.github/workflows/_dockerhub_publish.yaml
@@ -71,8 +71,10 @@ jobs:
             type=semver,pattern={{major}}
 
       - name: Tag and push to Docker Hub
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: |
-          for tag in ${{ steps.meta.outputs.tags }}; do
-            docker tag btschwertfeger/infinity-grid:build-artifact $tag
-            docker push $tag
+          echo "$TAGS" | while IFS= read -r tag; do
+            docker tag btschwertfeger/infinity-grid:build-artifact "$tag"
+            docker push "$tag"
           done

--- a/.github/workflows/_ghcr_publish.yaml
+++ b/.github/workflows/_ghcr_publish.yaml
@@ -72,15 +72,17 @@ jobs:
 
       - name: Tag and push to GHCR
         id: push
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           DIGEST=""
-          for tag in ${{ steps.meta.outputs.tags }}; do
-            docker tag btschwertfeger/infinity-grid:build-artifact $tag
-            docker push $tag
+          echo "$TAGS" | while IFS= read -r tag; do
+            docker tag btschwertfeger/infinity-grid:build-artifact "$tag"
+            docker push "$tag"
 
             # Get digest from the first pushed tag
             if [ -z "$DIGEST" ]; then
-              DIGEST=$(docker image inspect $tag --format='{{index .RepoDigests 0}}' | cut -d'@' -f2)
+              DIGEST=$(docker image inspect "$tag" --format='{{index .RepoDigests 0}}' | cut -d'@' -f2)
             fi
           done
 

--- a/.github/workflows/_ghcr_publish.yaml
+++ b/.github/workflows/_ghcr_publish.yaml
@@ -64,11 +64,10 @@ jobs:
           tags: |
             type=schedule
             type=ref,event=branch
-            type=ref,event=tag
             type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=ref,event=tag
+            type=semver,pattern=v{{major}}.{{minor}}-latest
+            type=semver,pattern=v{{major}}-latest
 
       - name: Tag and push to GHCR
         id: push

--- a/.github/workflows/_ghcr_publish.yaml
+++ b/.github/workflows/_ghcr_publish.yaml
@@ -75,7 +75,7 @@ jobs:
           TAGS: ${{ steps.meta.outputs.tags }}
         run: |
           DIGEST=""
-          echo "$TAGS" | while IFS= read -r tag; do
+          while IFS= read -r tag; do
             docker tag btschwertfeger/infinity-grid:build-artifact "$tag"
             docker push "$tag"
 
@@ -83,7 +83,7 @@ jobs:
             if [ -z "$DIGEST" ]; then
               DIGEST=$(docker image inspect "$tag" --format='{{index .RepoDigests 0}}' | cut -d'@' -f2)
             fi
-          done
+          done <<< "$TAGS"
 
           echo "digest=$DIGEST" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
Fixing the syntax error that lead to failing image upload in release v1.2.0.

Also updating the version schema for container images.