### PR TITLE
Resolve "Container registry cleanup missing"

### DIFF
--- a/.github/workflows/weekly_registry_cleanup.yaml
+++ b/.github/workflows/weekly_registry_cleanup.yaml
@@ -1,6 +1,6 @@
 # -*- mode: yaml; coding: utf-8 -*-
 #
-# Copyright (C) 2023 Benjamin Thomas Schwertfeger
+# Copyright (C) 2025 Benjamin Thomas Schwertfeger
 # All rights reserved.
 # https://github.com/btschwertfeger
 #
@@ -19,7 +19,6 @@ jobs:
     permissions:
       packages: write
       contents: read
-
     steps:
       - name: Delete untagged images from GHCR
         env:


### PR DESCRIPTION
Adding a workflow that runs once a month to cleanup the container registry from versions that do not have any assigned tag.

Closes #28 