### PR TITLE
Resolve "Kraken assets like ETH that translate to XETH via REST are not tradable"

### DIFF
--- a/src/infinity_grid/adapters/exchanges/kraken.py
+++ b/src/infinity_grid/adapters/exchanges/kraken.py
@@ -370,6 +370,11 @@ class KrakenExchangeRESTServiceAdapter(IExchangeRESTService):
                 # will return AVAX and ZEUR or DOT ZEUR. So we need to cut of
                 # the Z in case.
                 key = key[1:]  # noqa: PLW2901
+            elif key.startswith("X") and key[1:] in assets:
+                # Assets like ETH will be named like XETH. Pair like ETH/USD
+                # will be returned as XETH and ZUSD, so we need to cut of the X
+                # in case.
+                key = key[1:]  # noqa: PLW2901
 
             if key == self.__base_currency:
                 base_currency = value["altname"]


### PR DESCRIPTION
Since assets like ETH are named XETH when fetching assets via REST (similar to currencies that are prefixed with "Z"), the leading "X" must be removed to properly handle assets like these.

Closes #68 