### PR TITLE
Resolve "Test Python 3.14 support"

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13"] # just for compatibility reasons
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}
@@ -69,7 +69,7 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13", "3.14"]
     with:
       os: ${{ matrix.os }}
       python-version: ${{ matrix.python-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 # https://github.com/btschwertfeger
 #
 
-FROM python:3.13-slim-bookworm
+FROM python:3.14-slim-bookworm
 
 ARG EXTRAS="kraken"
 ARG VERSION


### PR DESCRIPTION
Run tests against Python 3.14 and use this version as base for building the container image.

Closes #83 